### PR TITLE
FIX impossible to import custom attributes

### DIFF
--- a/Model/Reader/product-import.xsd
+++ b/Model/Reader/product-import.xsd
@@ -92,6 +92,7 @@
 				<xs:element ref="custom_option_values" minOccurs="0"/>
 				<xs:element ref="delete" minOccurs="0"/>
 				<xs:element ref="select" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="custom" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="multi_select" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="role" minOccurs="0" maxOccurs="unbounded"/>
 			</xs:choice>
@@ -142,6 +143,7 @@
 				<xs:element ref="custom_option_values" minOccurs="0"/>
 				<xs:element ref="delete" minOccurs="0"/>
 				<xs:element ref="select" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="custom" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="multi_select" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="role" minOccurs="0" maxOccurs="unbounded"/>
 			</xs:choice>


### PR DESCRIPTION
The validation for the field custom fail due the missing node in the xsd declaration.
After this small fix the import with custom attributes runs without any problem using the node:

<custom code"yourCustomAttribute">yourCustomValue</custom>
