### PR TITLE
added preserve images option

### DIFF
--- a/Api/ImportConfig.php
+++ b/Api/ImportConfig.php
@@ -197,6 +197,13 @@ class ImportConfig
     const IMAGE_STRATEGY_SET = 'set'; // Add and update images; and also remove existing product images not named in the import
 
     /**
+     * When imageStrategy is set to IMAGE_STRATEGY_SET, should existing videos and video thumbnails be preserved?
+     *
+     * @var string
+     */
+    public $preserveExistingVideos = false;
+
+    /**
      * How to handle products that change type?
      *
      * @var string

--- a/Model/Resource/ProductStorage.php
+++ b/Model/Resource/ProductStorage.php
@@ -342,7 +342,8 @@ class ProductStorage
         $this->linkedProductStorage->updateLinkedProducts($validProducts);
         $this->imageStorage->storeProductImages($validProducts,
             $config->imageStrategy === ImportConfig::IMAGE_STRATEGY_SET,
-            $config->existingImageStrategy == ImportConfig::EXISTING_IMAGE_STRATEGY_FORCE_DOWNLOAD);
+            $config->existingImageStrategy == ImportConfig::EXISTING_IMAGE_STRATEGY_FORCE_DOWNLOAD,
+            $config->preserveExistingVideos);
         $this->tierPriceStorage->updateTierPrices($validProducts);
 
         // url_rewrite (must be done after url_key and category_id)


### PR DESCRIPTION
If the image strategy is set to IMAGE_STRATEGY_SET, it will also remove all existing videos. To prevent this, I have added an option to preserve the existing videos when the preserveExistingVideos flag is set to true.