### PR TITLE
[Feature] Ability to skip product url rewrite processing

### DIFF
--- a/Api/ImportConfig.php
+++ b/Api/ImportConfig.php
@@ -208,6 +208,16 @@ class ImportConfig
     const PRODUCT_TYPE_CHANGE_NON_DESTRUCTIVE = 'non-destructive'; // allow only product type changes that do not delete data
 
     /**
+     * Handle rewrites?
+     *
+     * @var bool
+     */
+    public $handleRewrites = self::HANDLE_REWRITES_TRUE;
+
+    const HANDLE_REWRITES_TRUE = true;
+    const HANDLE_REWRITES_FALSE = false;
+
+    /**
      * How to handle url_rewrite 301 redirects?
      *
      * @var string

--- a/Model/Resource/ProductStorage.php
+++ b/Model/Resource/ProductStorage.php
@@ -189,7 +189,7 @@ class ProductStorage
         $this->productEntityStorage->checkIfIdsExist($products);
 
         // distinguish between inserts and updates (and assign ids)
-        list(, $updateProducts) = $this->assignProductIds($products);
+        [, $updateProducts] = $this->assignProductIds($products);
 
         // replace reference(s) with ids; changes $product->errors
         $this->referenceResolver->resolveExternalReferences($products, $config);
@@ -311,7 +311,7 @@ class ProductStorage
         // start by removing old structures and setting attributes (virtual!)
         $this->productTypeChanger->performTypeChanges($validUpdateProducts);
 
-        list($upsertAttributes, $deleteAttributes) = $this->separateUpsertsFromDeletes($validProducts, $config);
+        [$upsertAttributes, $deleteAttributes] = $this->separateUpsertsFromDeletes($validProducts, $config);
 
         $this->productEntityStorage->insertMainTable($validInsertProducts);
         $this->productEntityStorage->updateMainTable($validUpdateProducts);
@@ -346,9 +346,13 @@ class ProductStorage
         $this->tierPriceStorage->updateTierPrices($validProducts);
 
         // url_rewrite (must be done after url_key and category_id)
-        $this->urlRewriteStorage->updateRewrites($validProducts,
-            $config->handleRedirects === ImportConfig::KEEP_REDIRECTS,
-            $config->handleCategoryRewrites === ImportConfig::KEEP_CATEGORY_REWRITES);
+        if ($config->handleRewrites) {
+            $this->urlRewriteStorage->updateRewrites(
+                $validProducts,
+                $config->handleRedirects === ImportConfig::KEEP_REDIRECTS,
+                $config->handleCategoryRewrites === ImportConfig::KEEP_CATEGORY_REWRITES
+            );
+        }
 
         $this->downloadableStorage->performTypeSpecificStorage($productsByType[DownloadableProduct::TYPE_DOWNLOADABLE]);
         $this->groupedStorage->performTypeSpecificStorage($productsByType[GroupedProduct::TYPE_GROUPED]);


### PR DESCRIPTION
Hi,

This PR adds the ability to skip URL rewrite processing when saving products.

My current use-case is having issues when updating product information when no category information is passed to the product data object. This causes the url rewrite processor to throw exceptions, in my case it throws a duplicate primary key constraint.

There might be a deeper issue here, namely its trying to insert already existing entries into the `catalog_url_rewrite_product_category` table. This is probably caused by the lack of information given in the passed product data object and its url rewrite diff fails causing existing rewrites to be returned - and inserted. I have not tested this theory since adding a skip configuration option circumvents this issue altogether.