### PR TITLE
Removes deprecated PHP 8.4 and 8.5 usage. Also bumped minimum required PHP version to 8.1

### DIFF
--- a/Model/Persistence/HttpCache.php
+++ b/Model/Persistence/HttpCache.php
@@ -182,7 +182,6 @@ class HttpCache
         $error = curl_error($ch);
         $httpResponseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        curl_close($ch);
         fclose($fp);
 
         if ($conditions) {

--- a/Model/Reader/XmlProductReader.php
+++ b/Model/Reader/XmlProductReader.php
@@ -144,7 +144,6 @@ class XmlProductReader
         }
 
         // close
-        xml_parser_free($parser);
         fclose($stream);
     }
 }

--- a/Test/Integration/UrlRewriteTest.php
+++ b/Test/Integration/UrlRewriteTest.php
@@ -53,7 +53,7 @@ class UrlRewriteTest extends \Magento\TestFramework\TestCase\AbstractController
         self::$db->execute("DELETE FROM `{$table}` WHERE request_path LIKE '%product-import.html'");
     }
 
-    public function __construct(string $name = null, array $data = array(), string $dataName = '')
+    public function __construct(?string $name = null, array $data = array(), string $dataName = '')
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
 
@@ -83,7 +83,7 @@ class UrlRewriteTest extends \Magento\TestFramework\TestCase\AbstractController
         foreach ([$c2b => 'colored-things/containers', $c2c => 'large'] as $id => $urlPath) {
             $path = self::$db->fetchSingleCell("
             SELECT value FROM catalog_category_entity_varchar
-            WHERE store_id = 0 AND entity_id = :cat AND attribute_id = 
+            WHERE store_id = 0 AND entity_id = :cat AND attribute_id =
                 (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'url_path' AND entity_type_id = 3)
         ", [
                 'cat' => $id

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fast product import library for Magento 2",
     "type": "magento2-module",
     "require": {
-      "php": "~7.0|^8.0"
+      "php": "^8.1"
     },
     "license": [
         "MIT"
@@ -17,4 +17,3 @@
         }
     }
 }
-


### PR DESCRIPTION
Fixes these 3 issues [PHPCompatibility tool](https://github.com/PHPCompatibility/PHPCompatibility/) found:
```
FILE: vendor/bigbridge/product-import/Test/Integration/UrlRewriteTest.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 56 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $name. (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: vendor/bigbridge/product-import/Model/Persistence/HttpCache.php
----------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------
 185 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
----------------------------------------------------------------------------------------------------------------------------------------


FILE: vendor/bigbridge/product-import/Model/Reader/XmlProductReader.php
--------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------------------------------------
 147 | WARNING | Function xml_parser_free() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated)
--------------------------------------------------------------------------------------------------------------------------------------------------

Time: 650ms; Memory: 20MB
```

The `curl_close` and `xml_parser_free` functions don't execute anything since PHP 8.0 according to [their](https://www.php.net/manual/en/function.xml-parser-free.php) [documentation](https://www.php.net/manual/en/function.curl-close.php) pages:
> Note:
> 
> This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
So we now only call them when at runtime we detect that and older PHP version is being used.

We can even simplify the code some more by removing those checks and the function calls if we move the minimum required PHP version to 8.0 in the `composer.json` file, but I'm not sure if you guys are willing to do that already?

----

I also increased the minimum required PHP version in the `composer.json` file to 7.1, as the nullable types introduced in this PR and in https://github.com/bigbridge-nl/product-import/pull/63 are not compatible with PHP 7.0
