### PR TITLE
Adds compatibility with symfony/console v7.x

### DIFF
--- a/Console/Command/ProductImportCommand.php
+++ b/Console/Command/ProductImportCommand.php
@@ -208,7 +208,7 @@ class ProductImportCommand extends Command
      * @return int|null
      * @throws \Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var XmlProductReader $xmlProductReader */
         $xmlProductReader = $this->objectManager->create(XmlProductReader::class);

--- a/Console/Command/ProductUrlRewriteCommand.php
+++ b/Console/Command/ProductUrlRewriteCommand.php
@@ -72,7 +72,7 @@ class ProductUrlRewriteCommand extends Command
      * @return int|null
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var UrlRewriteUpdater $urlRewriteUpdater */
         $urlRewriteUpdater = $this->objectManager->create(UrlRewriteUpdater::class);


### PR DESCRIPTION
Adds compatibility with `symfony/console` 7.x so we can use this module on Magento 2.4.9

Otherwise we get this error when executing `bin/magento`:

```
$ bin/magento cache:flush
PHP Fatal error:  Declaration of BigBridge\ProductImport\Console\Command\ProductImportCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in vendor/bigbridge/product-import/Console/Command/ProductImportCommand.php on line 211
```

The addition of the `int` return type is backwards compatible with older versions of `symfony/console`, through php's [covariance](https://www.php.net/manual/en/language.oop5.variance.php#:~:text=Covariance%20allows%20a%20child%27s%20method%20to%20return%20a%20more%20specific%20type%20than%20the%20return%20type%20of%20its%20parent%27s%20method.).
